### PR TITLE
Add check for zero peers

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,10 @@ const checkNode = async (nodeUrl) => {
   // error
   //
   console.log(`${bestBlock} is our best block, ${bestPeerBlock} is the best peer block`);
+  if (nPeers === 0) {
+    console.log('No peers, throwing an error');
+    process.exit(1);
+  }
   if (nPeersAhead > nPeers / 2) {
     const storage = await readFileAsync('/tmp/nodeup.lastblock');
     const lastBlocknum = parseInt(storage.toString());


### PR DESCRIPTION
Add a check for nodeup to make sure that the current node is connected to at least one peer; otherwise fail with process.exit(1).

Tested on bootnode 9.